### PR TITLE
Accept otp.bin that is 264 bytes long.

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function handleRequest(req, res){
 
       var exitWithNotValidOtp = function(newPath){
         res.writeHead(422)
-        res.end("you are trying to upload something different than 256 bytes, check your otp.bin!")
+        res.end("you are trying to upload something different than 256 or 264 bytes, check your otp.bin!")
         if(newPath){
           deleteFolderRecursive(newPath)
         }
@@ -67,14 +67,14 @@ function handleRequest(req, res){
               req.on('data', function(chunk) {
                 f.write(chunk)
                 totalSize += chunk.length
-                if(totalSize > 256){
+                if(totalSize > 264){
                   return exitWithNotValidOtp(newPath)
                 }
               })
 
               req.on('end', function() {
                 f.end()
-                if(totalSize != 256){
+                if(totalSize != 256 && totalSize != 264){
                   return exitWithNotValidOtp(newPath)  
                 }
                 f.on('close', function() {

--- a/interface.html
+++ b/interface.html
@@ -79,8 +79,8 @@
                     var files = e.dataTransfer.files
                     if(files.length !== 1){
                         addContent("Drop only your otp.bin here!", 1)
-                    } else if (files[0].size !== 256) {
-                        addContent("Your file is not 256 bytes long", 1)
+                    } else if (files[0].size !== 256 && files[0].size !== 264) {
+                        addContent("Your file is not 256 or 264 bytes long", 1)
                     } else {
                         addContent("Sending your otp now ...")
                         hashes = []


### PR DESCRIPTION
OTPHelper dumps 0x100 bytes as well as 0x108 for future TWL related use.
A9LH Sector generator only reads the first 90 bytes anyway:
https://github.com/delebile/arm9loaderhax/blob/master/common/sector_generator.py#L30
